### PR TITLE
Create one test for LanguageUtils.GetLanguageCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -351,3 +351,5 @@ MigrationBackup/
 
 GrammarNazi.App/Properties/launchSettings.json
 GrammarNazi.App/GrammarNazi.db
+
+.vscode

--- a/GrammarNazi.Tests/Utilities/LanguageUtilsTests.cs
+++ b/GrammarNazi.Tests/Utilities/LanguageUtilsTests.cs
@@ -1,0 +1,20 @@
+using GrammarNazi.Core.Utilities;
+using Xunit;
+
+namespace GrammarNazi.Tests.Utilities
+{
+    public class LanguageUtilsTests
+    {
+        [Theory]
+        [InlineData("eng", "en")]
+        [InlineData("spa", "es")]
+        public void GetLanguageCode_Should_ReturnExpectedResult(string actual, string expected)
+        {
+            // Arrange > Act
+            var result = LanguageUtils.GetLanguageCode(actual);
+
+            // Assert 
+            Assert.Equal(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
This is a small PR that creates a new test file for the LanguageUtils class.

It also implements one test for the GetLanguageCode method (a theory with two expected results).

I don't know if you accept these kinds of PRs but I thought it would be a fair contribution.

**MINOR:** modified .gitignore so my .vscode folder wouldn't be commited.