### PR TITLE
Fix different threads concurrently using the same DbContext

### DIFF
--- a/GrammarNazi.Tests/HostedServices/TelegramBotHostedServiceTests.cs
+++ b/GrammarNazi.Tests/HostedServices/TelegramBotHostedServiceTests.cs
@@ -14,7 +14,7 @@ namespace GrammarNazi.Tests.HostedServices
             // Arrange
             var telegramBotMock = new Mock<ITelegramBotClient>();
             var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource();
-            var hostedService = new TelegramBotHostedService(null, telegramBotMock.Object, null, null, null, null);
+            var hostedService = new TelegramBotHostedService(null, telegramBotMock.Object, null, null, null);
 
             // TODO: Create MessageEventArgs
             // We are currently not able to create a MessageEventArgs object


### PR DESCRIPTION
Fix #198 

This issue is happening because we are using the same instance of ```IChatConfigurationService``` (which is using ```IRepository```, which is using a ```DbContext```) for all messages received.

With this change, now we are getting a different instance for each message received.