### PR TITLE
Improve unit tests assertions

### DIFF
--- a/GrammarNazi.Tests/BotCommands/Telegram/AddWhiteListCommandTests.cs
+++ b/GrammarNazi.Tests/BotCommands/Telegram/AddWhiteListCommandTests.cs
@@ -38,7 +38,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             telegramBotClientMock.Setup(v => v.GetMeAsync(default))
@@ -51,7 +51,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
             await command.Handle(message);
 
             // Assert
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
 
         [Theory]
@@ -83,7 +83,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             chatConfigurationServiceMock.Setup(v => v.GetConfigurationByChatId(message.Chat.Id))
@@ -93,7 +93,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
             await command.Handle(message);
 
             // Assert
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
 
         [Fact]
@@ -128,7 +128,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             telegramBotClientMock.Setup(v => v.GetMeAsync(default))
@@ -142,7 +142,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
 
             // Assert
             Assert.Equal(2, chatConfig.WhiteListWords.Count);
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
     }
 }

--- a/GrammarNazi.Tests/BotCommands/Telegram/HideDetailsCommandTests.cs
+++ b/GrammarNazi.Tests/BotCommands/Telegram/HideDetailsCommandTests.cs
@@ -38,7 +38,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             telegramBotClientMock.Setup(v => v.GetMeAsync(default))
@@ -53,7 +53,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
             // Assert
             Assert.True(chatConfig.HideCorrectionDetails);
             chatConfigurationServiceMock.Verify(v => v.Update(chatConfig));
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
 
         [Fact]

--- a/GrammarNazi.Tests/BotCommands/Telegram/IntolerantCommandTests.cs
+++ b/GrammarNazi.Tests/BotCommands/Telegram/IntolerantCommandTests.cs
@@ -39,7 +39,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             chatConfigurationServiceMock.Setup(v => v.GetConfigurationByChatId(message.Chat.Id))
@@ -54,7 +54,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
             // Assert
             Assert.Equal(CorrectionStrictnessLevels.Intolerant, chatConfig.CorrectionStrictnessLevel);
             chatConfigurationServiceMock.Verify(v => v.Update(chatConfig));
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
 
         [Fact]

--- a/GrammarNazi.Tests/BotCommands/Telegram/LanguageCommandTests.cs
+++ b/GrammarNazi.Tests/BotCommands/Telegram/LanguageCommandTests.cs
@@ -41,7 +41,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             telegramBotClientMock.Setup(v => v.GetMeAsync(default))
@@ -54,7 +54,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
             await command.Handle(message);
 
             // Assert
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
 
         [Theory]
@@ -84,7 +84,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             chatConfigurationServiceMock.Setup(v => v.GetConfigurationByChatId(message.Chat.Id))
@@ -97,7 +97,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
             await command.Handle(message);
 
             // Assert
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
 
         [Theory]
@@ -127,7 +127,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             telegramBotClientMock.Setup(v => v.GetMeAsync(default))
@@ -141,7 +141,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
 
             // Assert
             Assert.Equal(languageParameter, chatConfig.SelectedLanguage);
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
 
         [Fact]

--- a/GrammarNazi.Tests/BotCommands/Telegram/RemoveWhiteListCommandTests.cs
+++ b/GrammarNazi.Tests/BotCommands/Telegram/RemoveWhiteListCommandTests.cs
@@ -38,7 +38,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             telegramBotClientMock.Setup(v => v.GetMeAsync(default))
@@ -51,7 +51,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
             await command.Handle(message);
 
             // Assert
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
 
         [Fact]
@@ -79,7 +79,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             chatConfigurationServiceMock.Setup(v => v.GetConfigurationByChatId(message.Chat.Id))
@@ -89,7 +89,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
             await command.Handle(message);
 
             // Assert
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
 
         [Fact]
@@ -128,7 +128,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             telegramBotClientMock.Setup(v => v.GetMeAsync(default))
@@ -142,7 +142,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
 
             // Assert
             Assert.Empty(chatConfig.WhiteListWords);
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
     }
 }

--- a/GrammarNazi.Tests/BotCommands/Telegram/SetAlgorithmCommandTests.cs
+++ b/GrammarNazi.Tests/BotCommands/Telegram/SetAlgorithmCommandTests.cs
@@ -41,7 +41,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             telegramBotClientMock.Setup(v => v.GetMeAsync(default))
@@ -54,7 +54,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
             await command.Handle(message);
 
             // Assert
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
 
         [Theory]
@@ -84,7 +84,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             telegramBotClientMock.Setup(v => v.GetMeAsync(default))
@@ -97,7 +97,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
             await command.Handle(message);
 
             // Assert
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
 
         [Fact]
@@ -134,7 +134,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             telegramBotClientMock.Setup(v => v.GetMeAsync(default))
@@ -148,7 +148,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
 
             // Assert
             Assert.Equal(algorithmParameter, chatConfig.GrammarAlgorithm);
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
     }
 }

--- a/GrammarNazi.Tests/BotCommands/Telegram/ShowDetailsCommandTests.cs
+++ b/GrammarNazi.Tests/BotCommands/Telegram/ShowDetailsCommandTests.cs
@@ -38,7 +38,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             telegramBotClientMock.Setup(v => v.GetMeAsync(default))
@@ -53,7 +53,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
             // Assert
             Assert.False(chatConfig.HideCorrectionDetails);
             chatConfigurationServiceMock.Verify(v => v.Update(chatConfig));
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
 
         [Fact]

--- a/GrammarNazi.Tests/BotCommands/Telegram/StartCommandTests.cs
+++ b/GrammarNazi.Tests/BotCommands/Telegram/StartCommandTests.cs
@@ -43,10 +43,6 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
             await command.Handle(message);
 
             // Assert
-
-            // Using message.Chat.Id due to an issue with ChatId.Equals method.
-            // We should be able to especify ChatId's after this PR gets merged https://github.com/TelegramBots/Telegram.Bot/pull/940
-            // and the Telegram.Bot nuget package updated.
             telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
 

--- a/GrammarNazi.Tests/BotCommands/Telegram/StartCommandTests.cs
+++ b/GrammarNazi.Tests/BotCommands/Telegram/StartCommandTests.cs
@@ -44,10 +44,10 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
 
             // Assert
 
-            // Using It.IsAny<ChatId>() due to an issue with ChatId.Equals method.
+            // Using message.Chat.Id due to an issue with ChatId.Equals method.
             // We should be able to especify ChatId's after this PR gets merged https://github.com/TelegramBots/Telegram.Bot/pull/940
             // and the Telegram.Bot nuget package updated.
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
 
         [Fact]
@@ -81,7 +81,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
             await command.Handle(message);
 
             // Assert
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default), Times.Once);
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default), Times.Once);
         }
 
         [Fact]
@@ -119,7 +119,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
             await command.Handle(message);
 
             // Assert
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
 
         [Fact]
@@ -147,7 +147,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             telegramBotClientMock.Setup(v => v.GetMeAsync(default))
@@ -162,7 +162,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
             // Assert
             Assert.False(chatConfig.IsBotStopped);
             chatConfigurationServiceMock.Verify(v => v.Update(chatConfig));
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
     }
 }

--- a/GrammarNazi.Tests/BotCommands/Telegram/StopCommandTests.cs
+++ b/GrammarNazi.Tests/BotCommands/Telegram/StopCommandTests.cs
@@ -38,7 +38,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             chatConfigurationServiceMock.Setup(v => v.GetConfigurationByChatId(message.Chat.Id))
@@ -50,7 +50,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
             // Assert
             Assert.True(chatConfig.IsBotStopped);
             chatConfigurationServiceMock.Verify(v => v.Update(chatConfig));
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
 
         [Fact]

--- a/GrammarNazi.Tests/BotCommands/Telegram/TolerantCommandTests.cs
+++ b/GrammarNazi.Tests/BotCommands/Telegram/TolerantCommandTests.cs
@@ -39,7 +39,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             telegramBotClientMock.Setup(v => v.GetMeAsync(default))
@@ -54,7 +54,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
             // Assert
             Assert.Equal(CorrectionStrictnessLevels.Tolerant, chatConfig.CorrectionStrictnessLevel);
             chatConfigurationServiceMock.Verify(v => v.Update(chatConfig));
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
 
         [Fact]

--- a/GrammarNazi.Tests/BotCommands/Telegram/WhiteListCommandTests.cs
+++ b/GrammarNazi.Tests/BotCommands/Telegram/WhiteListCommandTests.cs
@@ -38,7 +38,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             telegramBotClientMock.Setup(v => v.GetMeAsync(default))
@@ -51,7 +51,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
             await command.Handle(message);
 
             // Assert
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
 
         [Fact]
@@ -79,7 +79,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             chatConfigurationServiceMock.Setup(v => v.GetConfigurationByChatId(message.Chat.Id))
@@ -89,7 +89,7 @@ namespace GrammarNazi.Tests.BotCommands.Telegram
             await command.Handle(message);
 
             // Assert
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
     }
 }

--- a/GrammarNazi.Tests/Services/TelegramCommandHandlerServiceTests.cs
+++ b/GrammarNazi.Tests/Services/TelegramCommandHandlerServiceTests.cs
@@ -46,7 +46,7 @@ namespace GrammarNazi.Tests.Services
 
             var callbackQuery = new CallbackQuery { Message = message, From = message.From, Data = callBackQueryData };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             telegramBotClientMock.Setup(v => v.GetMeAsync(default))
@@ -92,7 +92,7 @@ namespace GrammarNazi.Tests.Services
 
             var callbackQuery = new CallbackQuery { Message = message, From = message.From, Data = callBackQueryData };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             telegramBotClientMock.Setup(v => v.GetMeAsync(default))
@@ -135,7 +135,7 @@ namespace GrammarNazi.Tests.Services
 
             var callbackQuery = new CallbackQuery { Message = message, From = message.From, Data = "" };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = 100 } } });
 
             telegramBotClientMock.Setup(v => v.GetMeAsync(default))
@@ -148,7 +148,7 @@ namespace GrammarNazi.Tests.Services
             await service.HandleCallBackQuery(callbackQuery);
 
             // Assert
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Markdown, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Markdown, default, false, false, 0, false, default, default));
         }
 
         [Theory]
@@ -172,7 +172,7 @@ namespace GrammarNazi.Tests.Services
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             // Act
@@ -181,7 +181,7 @@ namespace GrammarNazi.Tests.Services
             // Assert
 
             // Make sure SendTextMessageAsync method was never called
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.IsAny<string>(), ParseMode.Default, default, false, false, 0, false, default, default), Times.Never);
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.IsAny<string>(), ParseMode.Default, default, false, false, 0, false, default, default), Times.Never);
         }
 
         [Theory]
@@ -206,7 +206,7 @@ namespace GrammarNazi.Tests.Services
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new[] { new ChatMember { User = new() { Id = message.From.Id } } });
 
             // Act
@@ -215,7 +215,7 @@ namespace GrammarNazi.Tests.Services
             // Assert
 
             // Make sure SendTextMessageAsync method was never called
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.IsAny<string>(), ParseMode.Default, default, false, false, 0, false, default, default), Times.Never);
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.IsAny<string>(), ParseMode.Default, default, false, false, 0, false, default, default), Times.Never);
         }
 
         private IEnumerable<ITelegramBotCommand> GetAllCommands()

--- a/GrammarNazi.Tests/TestUtilities.cs
+++ b/GrammarNazi.Tests/TestUtilities.cs
@@ -48,14 +48,14 @@ namespace GrammarNazi.Tests
                 }
             };
 
-            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(It.IsAny<ChatId>(), default))
+            telegramBotClientMock.Setup(v => v.GetChatAdministratorsAsync(message.Chat.Id, default))
                 .ReturnsAsync(new ChatMember[0]);
 
             // Act
             await command.Handle(message);
 
             // Assert
-            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(It.IsAny<ChatId>(), It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
+            telegramBotClientMock.Verify(v => v.SendTextMessageAsync(message.Chat.Id, It.Is<string>(s => s.Contains(replyMessage)), ParseMode.Default, default, false, false, 0, false, default, default));
         }
     }
 }


### PR DESCRIPTION
We can use the correct assertion for ChatId since the existing bug (https://github.com/TelegramBots/Telegram.Bot/pull/940) was fixed in the last version of Telegram.Bot.