### PR TITLE
Sql exception fix after EF Core upgrade

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.100
+        dotnet-version: 7.0.100
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/GrammarNazi.App/Dockerfile
+++ b/GrammarNazi.App/Dockerfile
@@ -1,10 +1,10 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS build-env
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS build-env
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["GrammarNazi.App/GrammarNazi.App.csproj", "GrammarNazi.App/"]
 RUN dotnet restore "GrammarNazi.App/GrammarNazi.App.csproj"
@@ -18,7 +18,7 @@ FROM build AS publish
 RUN dotnet publish "GrammarNazi.App.csproj" -c Release -o /app/publish
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:6.0
+FROM mcr.microsoft.com/dotnet/aspnet:7.0
 WORKDIR /app
 COPY --from=publish /app/publish .
 CMD dotnet GrammarNazi.App.dll

--- a/GrammarNazi.App/GrammarNazi.App.csproj
+++ b/GrammarNazi.App/GrammarNazi.App.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
 

--- a/GrammarNazi.Core/GrammarNazi.Core.csproj
+++ b/GrammarNazi.Core/GrammarNazi.Core.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Discord.Net" Version="3.8.1" />
     <PackageReference Include="FirebaseDatabase.net" Version="4.1.0" />
     <PackageReference Include="Markdig" Version="0.30.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="NTextCat" Version="0.3.65" />
     <PackageReference Include="Octokit" Version="4.0.1" />
     <PackageReference Include="Polly" Version="7.2.3" />

--- a/GrammarNazi.Domain/GrammarNazi.Domain.csproj
+++ b/GrammarNazi.Domain/GrammarNazi.Domain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>GrammarNazi.Domain</AssemblyName>
   </PropertyGroup>
 

--- a/GrammarNazi.Tests/GrammarNazi.Tests.csproj
+++ b/GrammarNazi.Tests/GrammarNazi.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ Bot that corrects spelling mistakes.
 [@grammarNz_Bot](https://t.me/grammarNz_Bot): This bot analyzes each message that is sent in a Telegram chat, and if it finds any spelling or grammar errors, it replies to the message with its corrections using the asterisk symbol (*).
 
 #### Twitter Bot
-[@GrammarNBot](https://twitter.com/GrammarNBot) This Twitter bot analyzes the latest tweets of its followers, and if it finds any spelling or grammar errors, it will tweet a reply with its corrections using the asterisk symbol (*).
+[@GrammarNBot](https://twitter.com/GrammarNBot) Analyzes the tweet you're replying to mentioning the bot, and if it finds any spelling or grammar errors, it will tweet a reply with its corrections using the asterisk symbol (*).
 
 #### Discord Bot (Disabled, see [#344](https://github.com/nminaya/grammar-nazi-bot/issues/344))
 [Add Bot to Server](https://discord.com/oauth2/authorize?client_id=800422872770150431&permissions=523328&scope=bot): This bot analyzes each message that is sent in a Discord channel, and if it finds any spelling or grammar errors, it replies to the message with its corrections using the asterisk symbol (*).
 
 ## Features
 #### Twitter Bot
-- Evaluates Tweets of followers.
+- Evaluates Tweets where the bot is mentioned.
 - Multiple language support (English and Spanish).
 - Follow back automatically.
 #### Telegram and Discord Bot
@@ -24,7 +24,7 @@ Bot that corrects spelling mistakes.
 Take a look at the [Telegram Bot](https://github.com/nminaya/grammar-nazi-bot/wiki/GrammarNazi-Telegram-Bot) and [Discord Bot](https://github.com/nminaya/grammar-nazi-bot/wiki/GrammarNazi-Discord-Bot) documentation.
 
 ## Solution Design
-The solution design focuses on a basic Domain Driven Design techniques and implementation, while keeping the things as simple as possible but can be extended as needed. Multiple assemblies are used for separation of concerns to keep logic isolated from the other components. **.NET 6 C#** is the default framework and language for this application.
+The solution design focuses on a basic Domain Driven Design techniques and implementation, while keeping the things as simple as possible but can be extended as needed. Multiple assemblies are used for separation of concerns to keep logic isolated from the other components. **.NET 7 C#** is the default framework and language for this application.
 
 ### Assembly Layers
 -   **GrammarNazi.Domain**  - This assembly contains constants, entities and interfaces.
@@ -33,5 +33,4 @@ The solution design focuses on a basic Domain Driven Design techniques and imple
 -   **GrammarNazi.App**  - This assembly is the web-based application host.
 
 ## License
-
 This project uses the following license: [MIT](LICENSE)


### PR DESCRIPTION
Closes #527

The fix for #527 was simply adding `TrustServerCertificate=True` to the connection string. I already added it in the server. So this is good to go.