### PR TITLE
Handle ServiceUnavailable in GeminiApiClient

### DIFF
--- a/GrammarNazi.Core/Clients/GeminiApiClient.cs
+++ b/GrammarNazi.Core/Clients/GeminiApiClient.cs
@@ -1,6 +1,7 @@
 ﻿using GrammarNazi.Domain.Clients;
 using GrammarNazi.Domain.Entities.GeminiAPI;
 using GrammarNazi.Domain.Entities.Settings;
+using GrammarNazi.Domain.Exceptions;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using System;
@@ -28,6 +29,11 @@ public class GeminiApiClient(IHttpClientFactory httpClientFactory, IOptions<Gemi
 
         if (response.StatusCode != HttpStatusCode.OK)
         {
+            if (response.StatusCode == HttpStatusCode.ServiceUnavailable)
+            {
+                throw new GeminiServiceUnavailableException("Gemini API is currently unavailable.");
+            }
+
             throw new InvalidOperationException($"Unsuccessful Gemini API response {response.StatusCode}", new(await response.Content.ReadAsStringAsync()));
         }
 

--- a/GrammarNazi.Core/Services/CatchExceptionService.cs
+++ b/GrammarNazi.Core/Services/CatchExceptionService.cs
@@ -59,6 +59,9 @@ namespace GrammarNazi.Core.Services
                 case RequestException requestException:
                     HandleRequestException(requestException, githubIssueSection);
                     break;
+                case GeminiServiceUnavailableException:
+                    _logger.LogWarning(exception, exception.Message);
+                    break;
 
                 default:
                     HandleGeneralException(exception, githubIssueSection);

--- a/GrammarNazi.Domain/Exceptions/GeminiServiceUnavailableException.cs
+++ b/GrammarNazi.Domain/Exceptions/GeminiServiceUnavailableException.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace GrammarNazi.Domain.Exceptions;
+
+public class GeminiServiceUnavailableException : Exception
+{
+    public GeminiServiceUnavailableException()
+    {
+    }
+
+    public GeminiServiceUnavailableException(string message) : base(message)
+    {
+    }
+
+    public GeminiServiceUnavailableException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}


### PR DESCRIPTION
- Add GeminiServiceUnavailableException
- Throw GeminiServiceUnavailableException when Gemini API returns 503
- Catch GeminiServiceUnavailableException in CatchExceptionService and log a warning
- Add tests for the new scenario

Closes #818 