### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -1,10 +1,13 @@
 name: .NET Core
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+   branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/nminaya/grammar-nazi-bot/security/code-scanning/5](https://github.com/nminaya/grammar-nazi-bot/security/code-scanning/5)

The best way to fix this problem is to add a `permissions` block to the workflow, specifying the minimum required permissions for the jobs. For standard build/test jobs like this, only `contents: read` is needed (so Actions can check out code). This block should be added at the top level of the workflow file (after the `name:` and before `jobs:`), so it applies to all jobs unless overridden. No new methods, imports, or definitions are needed; only a YAML edit is required at the start of the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
