### PR TITLE
Fix DatamuseApiClient JsonReaderException

### DIFF
--- a/GrammarNazi.Core/Clients/DatamuseApiClient.cs
+++ b/GrammarNazi.Core/Clients/DatamuseApiClient.cs
@@ -29,14 +29,34 @@ public class DatamuseApiClient : IDatamuseApiClient
 
         var response = await httpClient.SendAsync(request);
 
+        if (!response.IsSuccessStatusCode)
+        {
+            return new()
+            {
+                Word = word,
+                SimilarWords = []
+            };
+        }
+
         var content = await response.Content.ReadAsStringAsync();
 
-        var result = JsonConvert.DeserializeObject<IEnumerable<WordSimilarity>>(content);
-
-        return new()
+        try
         {
-            Word = word,
-            SimilarWords = result
-        };
+            var result = JsonConvert.DeserializeObject<IEnumerable<WordSimilarity>>(content);
+
+            return new()
+            {
+                Word = word,
+                SimilarWords = result
+            };
+        }
+        catch (JsonReaderException)
+        {
+            return new()
+            {
+                Word = word,
+                SimilarWords = []
+            };
+        }
     }
 }

--- a/GrammarNazi.Tests/Clients/DatamuseApiClientTests.cs
+++ b/GrammarNazi.Tests/Clients/DatamuseApiClientTests.cs
@@ -1,0 +1,121 @@
+using GrammarNazi.Core.Clients;
+using NSubstitute;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Newtonsoft.Json;
+using System;
+using System.Linq;
+
+namespace GrammarNazi.Tests.Clients;
+
+public class DatamuseApiClientTests
+{
+    [Fact]
+    public async Task CheckWord_HtmlResponse_ReturnsEmptySimilarWords()
+    {
+        // Arrange
+        var httpClientFactoryMock = Substitute.For<IHttpClientFactory>();
+        var httpClient = new HttpClient(new MockHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            return new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("<html><body>Error</body></html>")
+            };
+        }))
+        {
+            BaseAddress = new Uri("https://api.datamuse.com/")
+        };
+
+        httpClientFactoryMock.CreateClient("datamuseApi").Returns(httpClient);
+
+        var client = new DatamuseApiClient(httpClientFactoryMock);
+
+        // Act
+        var result = await client.CheckWord("test", "en");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("test", result.Word);
+        Assert.Empty(result.SimilarWords);
+    }
+
+    [Fact]
+    public async Task CheckWord_NonSuccessStatusCode_ReturnsEmptySimilarWords()
+    {
+        // Arrange
+        var httpClientFactoryMock = Substitute.For<IHttpClientFactory>();
+        var httpClient = new HttpClient(new MockHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            return new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.InternalServerError,
+                Content = new StringContent("Internal Server Error")
+            };
+        }))
+        {
+            BaseAddress = new Uri("https://api.datamuse.com/")
+        };
+
+        httpClientFactoryMock.CreateClient("datamuseApi").Returns(httpClient);
+
+        var client = new DatamuseApiClient(httpClientFactoryMock);
+
+        // Act
+        var result = await client.CheckWord("test", "en");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("test", result.Word);
+        Assert.Empty(result.SimilarWords);
+    }
+
+    [Fact]
+    public async Task CheckWord_ValidJsonResponse_ReturnsSimilarWords()
+    {
+        // Arrange
+        var httpClientFactoryMock = Substitute.For<IHttpClientFactory>();
+        var httpClient = new HttpClient(new MockHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            return new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("[{\"word\":\"test\",\"score\":100}]")
+            };
+        }))
+        {
+            BaseAddress = new Uri("https://api.datamuse.com/")
+        };
+
+        httpClientFactoryMock.CreateClient("datamuseApi").Returns(httpClient);
+
+        var client = new DatamuseApiClient(httpClientFactoryMock);
+
+        // Act
+        var result = await client.CheckWord("test", "en");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("test", result.Word);
+        Assert.Single(result.SimilarWords);
+        Assert.Equal("test", result.SimilarWords.First().Word);
+    }
+
+    public class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _sendAsync;
+
+        public MockHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> sendAsync)
+        {
+            _sendAsync = sendAsync;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return _sendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/GrammarNazi.Tests/Clients/DatamuseApiClientTests.cs
+++ b/GrammarNazi.Tests/Clients/DatamuseApiClientTests.cs
@@ -104,7 +104,7 @@ public class DatamuseApiClientTests
         Assert.Equal("test", result.SimilarWords.First().Word);
     }
 
-    public class MockHttpMessageHandler : HttpMessageHandler
+    private class MockHttpMessageHandler : HttpMessageHandler
     {
         private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _sendAsync;
 


### PR DESCRIPTION
Modified DatamuseApiClient.CheckWord to handle non-success HTTP status codes and non-JSON responses (e.g., HTML error pages) by returning an empty list of similar words. This prevents the bot from crashing when the Datamuse API fails. Added unit tests to verify these failure scenarios.

Fixes #891

---
*PR created automatically by Jules for task [1923921787834531121](https://jules.google.com/task/1923921787834531121) started by @nminaya*