### PR TITLE
Handle Groq API TooManyRequests gracefully

### DIFF
--- a/GrammarNazi.Core/Clients/GroqApiClient.cs
+++ b/GrammarNazi.Core/Clients/GroqApiClient.cs
@@ -1,5 +1,6 @@
 using GrammarNazi.Domain.Clients;
 using GrammarNazi.Domain.Entities.Settings;
+using GrammarNazi.Domain.Exceptions;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using System;
@@ -53,6 +54,12 @@ public class GroqApiClient(IHttpClientFactory httpClientFactory, IOptions<GroqAp
         if (response.StatusCode != HttpStatusCode.OK)
         {
             var errorContent = await response.Content.ReadAsStringAsync();
+
+            if (response.StatusCode == HttpStatusCode.TooManyRequests)
+            {
+                throw new GroqRateLimitException("Groq API Rate limit reached.", new Exception(errorContent));
+            }
+
             throw new InvalidOperationException($"Unsuccessful Groq API response {response.StatusCode}", new Exception(errorContent));
         }
 

--- a/GrammarNazi.Core/Services/CatchExceptionService.cs
+++ b/GrammarNazi.Core/Services/CatchExceptionService.cs
@@ -62,6 +62,7 @@ namespace GrammarNazi.Core.Services
                     HandleRequestException(requestException, githubIssueSection);
                     break;
                 case GeminiServiceUnavailableException:
+                case GroqRateLimitException:
                     _logger.LogWarning(exception, exception.Message);
                     break;
 

--- a/GrammarNazi.Domain/Exceptions/GroqRateLimitException.cs
+++ b/GrammarNazi.Domain/Exceptions/GroqRateLimitException.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace GrammarNazi.Domain.Exceptions;
+
+public class GroqRateLimitException : Exception
+{
+    public GroqRateLimitException()
+    {
+    }
+
+    public GroqRateLimitException(string message) : base(message)
+    {
+    }
+
+    public GroqRateLimitException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/GrammarNazi.Tests/Clients/GroqApiClientTests.cs
+++ b/GrammarNazi.Tests/Clients/GroqApiClientTests.cs
@@ -1,0 +1,98 @@
+using GrammarNazi.Core.Clients;
+using GrammarNazi.Domain.Entities.Settings;
+using GrammarNazi.Domain.Exceptions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GrammarNazi.Tests.Clients;
+
+public class GroqApiClientTests
+{
+    [Fact]
+    public async Task GetChatCompletion_RateLimitResponse_ThrowsGroqRateLimitException()
+    {
+        // Arrange
+        var httpClientFactoryMock = Substitute.For<IHttpClientFactory>();
+        var optionsMock = Substitute.For<IOptions<GroqApiSettings>>();
+
+        optionsMock.Value.Returns(new GroqApiSettings
+        {
+            Model = "test-model",
+            ApiKey = "test-key"
+        });
+
+        var httpClient = new HttpClient(new MockHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            return new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.TooManyRequests,
+                Content = new StringContent("{\"error\":{\"message\":\"Rate limit reached\"}}")
+            };
+        }))
+        {
+            BaseAddress = new Uri("https://api.groq.com/")
+        };
+
+        httpClientFactoryMock.CreateClient("groqApi").Returns(httpClient);
+
+        var client = new GroqApiClient(httpClientFactoryMock, optionsMock);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<GroqRateLimitException>(() => client.GetChatCompletion("system", "user"));
+    }
+
+    [Fact]
+    public async Task GetChatCompletion_OtherErrorResponse_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var httpClientFactoryMock = Substitute.For<IHttpClientFactory>();
+        var optionsMock = Substitute.For<IOptions<GroqApiSettings>>();
+
+        optionsMock.Value.Returns(new GroqApiSettings
+        {
+            Model = "test-model",
+            ApiKey = "test-key"
+        });
+
+        var httpClient = new HttpClient(new MockHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            return new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.InternalServerError,
+                Content = new StringContent("Internal Server Error")
+            };
+        }))
+        {
+            BaseAddress = new Uri("https://api.groq.com/")
+        };
+
+        httpClientFactoryMock.CreateClient("groqApi").Returns(httpClient);
+
+        var client = new GroqApiClient(httpClientFactoryMock, optionsMock);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetChatCompletion("system", "user"));
+        Assert.Contains("Unsuccessful Groq API response InternalServerError", exception.Message);
+    }
+
+    private class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _sendAsync;
+
+        public MockHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> sendAsync)
+        {
+            _sendAsync = sendAsync;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return _sendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/GrammarNazi.Tests/Services/CatchExceptionServiceTests.cs
+++ b/GrammarNazi.Tests/Services/CatchExceptionServiceTests.cs
@@ -78,6 +78,27 @@ namespace GrammarNazi.Tests.Services
             githubServiceMock.DidNotReceive().CreateBugIssue(Arg.Any<string>(), Arg.Any<Exception>(), Arg.Any<GithubIssueLabels>());
         }
 
+        [Fact]
+        public void HandleException_GroqRateLimitException_Should_LogWarning()
+        {
+            // Arrange
+            var loggerMock = Substitute.For<ILogger<CatchExceptionService>>();
+            var githubServiceMock = Substitute.For<IGithubService>();
+            var service = new CatchExceptionService(githubServiceMock, loggerMock);
+            var exception = new GroqRateLimitException("Groq rate limit reached");
+
+            // Act
+            service.HandleException(exception, GithubIssueLabels.ProductionBug);
+
+            // Assert
+            var numberOfCalls = loggerMock.ReceivedCalls()
+                .Select(call => call.GetArguments())
+                .Count(callArguments => ((LogLevel)callArguments[0]).Equals(LogLevel.Warning));
+
+            Assert.Equal(1, numberOfCalls);
+            githubServiceMock.DidNotReceive().CreateBugIssue(Arg.Any<string>(), Arg.Any<Exception>(), Arg.Any<GithubIssueLabels>());
+        }
+
         [Theory]
         [InlineData("Bot API Request timed out")]
         public void HandleException_RequestException_Timeout_Should_LogWarning(string exceptionMessage)


### PR DESCRIPTION
This change addresses issue #900 where the Groq API returns a 429 TooManyRequests error, causing the bot to automatically create a GitHub issue. 

I've implemented the following:
1. Created `GroqRateLimitException` in `GrammarNazi.Domain`.
2. Modified `GroqApiClient` to detect `HttpStatusCode.TooManyRequests` and throw the new exception.
3. Updated `CatchExceptionService` to handle `GroqRateLimitException` by logging it as a warning.
4. Added unit tests for `GroqApiClient` and a test case in `CatchExceptionServiceTests` to verify the new behavior.

---
*PR created automatically by Jules for task [12581250893001814149](https://jules.google.com/task/12581250893001814149) started by @nminaya*