### PR TITLE
Handle Groq HttpClient timeout better (issue #932)

### DIFF
--- a/GrammarNazi.App/HostedServices/TelegramBotHostedService.cs
+++ b/GrammarNazi.App/HostedServices/TelegramBotHostedService.cs
@@ -1,9 +1,13 @@
 ﻿using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Telegram.Bot;
 using Telegram.Bot.Polling;
+using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
 
 namespace GrammarNazi.App.HostedServices;
@@ -13,6 +17,9 @@ public class TelegramBotHostedService : BackgroundService
     private readonly ILogger<TelegramBotHostedService> _logger;
     private readonly ITelegramBotClient _client;
     private readonly IUpdateHandler _updateHandler;
+    private readonly Channel<Update> _updateChannel;
+
+    private const int MaxWorkers = 5;
 
     public TelegramBotHostedService(ILogger<TelegramBotHostedService> logger,
         ITelegramBotClient telegramBotClient,
@@ -21,6 +28,7 @@ public class TelegramBotHostedService : BackgroundService
         _logger = logger;
         _client = telegramBotClient;
         _updateHandler = updateHandler;
+        _updateChannel = Channel.CreateUnbounded<Update>();
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -28,12 +36,37 @@ public class TelegramBotHostedService : BackgroundService
         _logger.LogInformation("Telegram Bot Hosted Service started");
 
         _client.StartReceiving(
-            updateHandler: _updateHandler.HandleUpdateAsync,
+            updateHandler: (botClient, update, cancellationToken) =>
+            {
+                _updateChannel.Writer.TryWrite(update);
+                return Task.CompletedTask;
+            },
             errorHandler: _updateHandler.HandleErrorAsync,
             receiverOptions: new() { AllowedUpdates = new[] { UpdateType.Message, UpdateType.CallbackQuery } },
             cancellationToken: stoppingToken);
 
+        var workers = Enumerable.Range(0, MaxWorkers)
+            .Select(_ => Task.Run(() => Worker(stoppingToken), stoppingToken));
+
         // Keep hosted service alive while receiving messages
-        await Task.Delay(Timeout.Infinite, stoppingToken);
+        await Task.WhenAll(workers);
+    }
+
+    private async Task Worker(CancellationToken stoppingToken)
+    {
+        while (await _updateChannel.Reader.WaitToReadAsync(stoppingToken))
+        {
+            while (_updateChannel.Reader.TryRead(out var update))
+            {
+                try
+                {
+                    await _updateHandler.HandleUpdateAsync(_client, update, stoppingToken);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error while processing update inside Telegram worker pool.");
+                }
+            }
+        }
     }
 }

--- a/GrammarNazi.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/GrammarNazi.Core/Extensions/ServiceCollectionExtensions.cs
@@ -19,18 +19,18 @@ public static class ServiceCollectionExtensions
 
     public static IServiceCollection AddNamedHttpClients(this IServiceCollection serviceCollection)
     {
-        serviceCollection.AddHttpClient("datamuseApi", c => c.BaseAddress = new Uri("https://api.datamuse.com/"));
-        serviceCollection.AddHttpClient("languageToolApi", c => c.BaseAddress = new Uri("https://languagetool.org/"));
-        serviceCollection.AddHttpClient("yandexSpellerApi", c => c.BaseAddress = new Uri("https://speller.yandex.net/"));
-        serviceCollection.AddHttpClient("sentimApi", c => c.BaseAddress = new Uri("https://sentim-api.herokuapp.com/"));
-        serviceCollection.AddHttpClient("geminiApi", c => c.BaseAddress = new Uri("https://generativelanguage.googleapis.com/"));
-        serviceCollection.AddHttpClient("groqApi", c => c.BaseAddress = new Uri("https://api.groq.com/"));
-        serviceCollection.AddHttpClient("cerebrasApi", c => c.BaseAddress = new Uri("https://api.cerebras.ai/"));
+        serviceCollection.AddHttpClient("datamuseApi", c => { c.BaseAddress = new Uri("https://api.datamuse.com/"); c.Timeout = TimeSpan.FromSeconds(30); });
+        serviceCollection.AddHttpClient("languageToolApi", c => { c.BaseAddress = new Uri("https://languagetool.org/"); c.Timeout = TimeSpan.FromSeconds(30); });
+        serviceCollection.AddHttpClient("yandexSpellerApi", c => { c.BaseAddress = new Uri("https://speller.yandex.net/"); c.Timeout = TimeSpan.FromSeconds(30); });
+        serviceCollection.AddHttpClient("sentimApi", c => { c.BaseAddress = new Uri("https://sentim-api.herokuapp.com/"); c.Timeout = TimeSpan.FromSeconds(30); });
+        serviceCollection.AddHttpClient("geminiApi", c => { c.BaseAddress = new Uri("https://generativelanguage.googleapis.com/"); c.Timeout = TimeSpan.FromSeconds(30); });
+        serviceCollection.AddHttpClient("groqApi", c => { c.BaseAddress = new Uri("https://api.groq.com/"); c.Timeout = TimeSpan.FromSeconds(30); });
+        serviceCollection.AddHttpClient("cerebrasApi", c => { c.BaseAddress = new Uri("https://api.cerebras.ai/"); c.Timeout = TimeSpan.FromSeconds(30); });
 
         var meaningCloudSettings = serviceCollection.BuildServiceProvider().GetService<IOptions<MeaningCloudSettings>>().Value;
 
-        serviceCollection.AddHttpClient("meaninCloudSentimentAnalysisApi", c => c.BaseAddress = new Uri(meaningCloudSettings.MeaningCloudSentimentHostUrl));
-        serviceCollection.AddHttpClient("meaninCloudLanguageApi", c => c.BaseAddress = new Uri(meaningCloudSettings.MeaningCloudLanguageHostUrl));
+        serviceCollection.AddHttpClient("meaninCloudSentimentAnalysisApi", c => { c.BaseAddress = new Uri(meaningCloudSettings.MeaningCloudSentimentHostUrl); c.Timeout = TimeSpan.FromSeconds(30); });
+        serviceCollection.AddHttpClient("meaninCloudLanguageApi", c => { c.BaseAddress = new Uri(meaningCloudSettings.MeaningCloudLanguageHostUrl); c.Timeout = TimeSpan.FromSeconds(30); });
 
         return serviceCollection;
     }

--- a/GrammarNazi.Core/Services/CatchExceptionService.cs
+++ b/GrammarNazi.Core/Services/CatchExceptionService.cs
@@ -13,6 +13,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Mail;
 using System.Net.Sockets;
+using System.Threading.Tasks;
 using Telegram.Bot.Exceptions;
 using Tweetinvi.Exceptions;
 
@@ -63,6 +64,7 @@ namespace GrammarNazi.Core.Services
                     break;
                 case ExternalApiUnavailableException:
                 case GroqRateLimitException:
+                case TaskCanceledException when exception.InnerException is TimeoutException:
                     _logger.LogWarning(exception, exception.Message);
                     break;
 

--- a/GrammarNazi.Tests/Services/CatchExceptionServiceTests.cs
+++ b/GrammarNazi.Tests/Services/CatchExceptionServiceTests.cs
@@ -79,6 +79,49 @@ namespace GrammarNazi.Tests.Services
         }
 
         [Fact]
+        public void HandleException_TaskCanceledExceptionWithInnerTimeoutException_Should_LogWarning()
+        {
+            // Arrange
+            var loggerMock = Substitute.For<ILogger<CatchExceptionService>>();
+            var githubServiceMock = Substitute.For<IGithubService>();
+            var service = new CatchExceptionService(githubServiceMock, loggerMock);
+            var timeoutException = new TimeoutException("The operation timed out.");
+            var exception = new TaskCanceledException("Task canceled due to timeout", timeoutException);
+
+            // Act
+            service.HandleException(exception, GithubIssueLabels.Telegram);
+
+            // Assert
+            var numberOfCalls = loggerMock.ReceivedCalls()
+                .Select(call => call.GetArguments())
+                .Count(callArguments => ((LogLevel)callArguments[0]).Equals(LogLevel.Warning));
+
+            Assert.Equal(1, numberOfCalls);
+            githubServiceMock.DidNotReceive().CreateBugIssue(Arg.Any<string>(), Arg.Any<Exception>(), Arg.Any<GithubIssueLabels>());
+        }
+
+        [Fact]
+        public void HandleException_TaskCanceledExceptionWithoutInnerException_Should_LogErrorAndCreateBugIssue()
+        {
+            // Arrange
+            var loggerMock = Substitute.For<ILogger<CatchExceptionService>>();
+            var githubServiceMock = Substitute.For<IGithubService>();
+            var service = new CatchExceptionService(githubServiceMock, loggerMock);
+            var exception = new TaskCanceledException("Task canceled normally");
+
+            // Act
+            service.HandleException(exception, GithubIssueLabels.Telegram);
+
+            // Assert
+            var numberOfCalls = loggerMock.ReceivedCalls()
+                .Select(call => call.GetArguments())
+                .Count(callArguments => ((LogLevel)callArguments[0]).Equals(LogLevel.Error));
+
+            Assert.Equal(1, numberOfCalls);
+            githubServiceMock.Received().CreateBugIssue("Application Exception: Task canceled normally", exception, GithubIssueLabels.Telegram);
+        }
+
+        [Fact]
         public void HandleException_GroqRateLimitException_Should_LogWarning()
         {
             // Arrange


### PR DESCRIPTION
This PR resolves issue #932 by addressing the slow-fail stall on Groq API and other named HTTP clients:
1. Classified TaskCanceledException with inner TimeoutException as transient warnings in CatchExceptionService to eliminate automated issue noise for network stalls.
2. Configured an explicit 30-second timeout on all named HttpClients.
3. Reworked TelegramBotHostedService update processing using a 5-worker System.Threading.Channels pool to handle incoming updates concurrently, mirroring the robust architecture in DiscordBotHostedService.
4. Added new unit tests verifying the classification of TimeoutExceptions and general TaskCanceledExceptions.

---
*PR created automatically by Jules for task [1875156553015310710](https://jules.google.com/task/1875156553015310710) started by @nminaya*